### PR TITLE
Add test vectors from Schneier's site

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
 
 [[package]]
+name = "rstest"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11badbd6119f6956c1776bad8d71fc162a99f3d52a117fff2eec7349cad4d96b"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
 name = "solitaire"
 version = "0.1.0"
 dependencies = [
@@ -251,6 +288,7 @@ dependencies = [
  "lazy_static",
  "rand",
  "regex",
+ "rstest",
  "structopt",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ regex = "1.3"
 structopt = "0.3"
 thiserror = "1.0"
 
+[dev-dependencies]
+rstest = "0.5"
+
 [features]
 default = []
 small-deck-tests = []

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -59,6 +59,14 @@ impl fmt::Display for Deck {
     }
 }
 
+impl PartialEq for Deck {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.len() == other.0.len() && self.0.iter().zip(other.0.iter()).all(|(a, b)| a == b)
+    }
+}
+
+impl Eq for Deck {}
+
 impl Deck {
     /// Generate a new deck in sorted order
     pub fn new() -> Deck {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,10 @@ mod tests {
     fn vectors(plain: &str, key: &str, output: Option<Vec<u8>>, cipher: &str) {
         dbg!(key);
         let deck = Deck::from_passphrase(key);
-        if let Some(output) = output {
+        if let Some(mut output) = output {
+            // the output vectors include the jokers, which are excluded from
+            // keystream's output
+            output.retain(|v| *v < 53);
             assert_eq!(
                 keystream(deck.clone())
                     .take(output.len())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub fn decrypt(deck: Deck, text: &str) -> String {
 #[cfg(all(test, not(feature = "small-deck-tests")))]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     /// This test is a truncated version of the first test in the book.
@@ -179,105 +180,103 @@ mod tests {
         assert_eq!(Deck::from_passphrase(""), Deck::new(),)
     }
 
-    #[test]
     /// tests from the vectors at: https://www.schneier.com/code/sol-test.txt
-    fn test_vectors() {
-        for (plain, key, output, cipher) in &[
-            (
-                "AAAAAAAAAAAAAAA",
-                "",
-                Some(vec![
-                    4, 49, 10, 53, 24, 8, 51, 44, 6, 4, 33, 20, 39, 19, 34, 42,
-                ]),
-                "EXKYI ZSGEH UNTIQ",
-            ),
-            (
-                "AAAAAAAAAAAAAAA",
-                "f",
-                Some(vec![49, 24, 8, 46, 16, 1, 12, 33, 10, 10, 9, 27, 4, 32, 24]),
-                "XYIUQ BMHKK JBEGY",
-            ),
-            (
-                "AAAAAAAAAAAAAAA",
-                "fo",
-                Some(vec![
-                    19, 46, 9, 24, 12, 1, 4, 43, 11, 32, 23, 39, 29, 34, 22,
-                ]),
-                "TUJYM BERLG XNDIW",
-            ),
-            (
-                "AAAAAAAAAAAAAAA",
-                "foo",
-                Some(vec![
-                    8, 19, 7, 25, 20, 53, 9, 8, 22, 32, 43, 5, 26, 17, 53, 38, 48,
-                ]),
-                "ITHZU JIWGR FARMW",
-            ),
-            (
-                "AAAAAAAAAAAAAAA",
-                "a",
-                Some(vec![
-                    49, 14, 3, 26, 11, 32, 18, 2, 46, 37, 34, 42, 13, 18, 28,
-                ]),
-                "XODAL GSCUL IQNSC",
-            ),
-            (
-                "AAAAAAAAAAAAAAA",
-                "aa",
-                Some(vec![14, 7, 32, 22, 38, 23, 23, 2, 26, 8, 12, 2, 34, 16, 15]),
-                "OHGWM XXCAI MCIQP",
-            ),
-            (
-                "AAAAAAAAAAAAAAA",
-                "aaa",
-                Some(vec![
-                    3, 28, 18, 42, 24, 33, 1, 16, 51, 53, 39, 6, 29, 43, 46, 45,
-                ]),
-                "DCSQY HBQZN GDRUT",
-            ),
-            (
-                "AAAAAAAAAAAAAAA",
-                "b",
-                Some(vec![
-                    49, 16, 4, 30, 12, 40, 8, 19, 37, 25, 47, 29, 18, 16, 18,
-                ]),
-                "XQEEM OITLZ VDSQS",
-            ),
-            (
-                "AAAAAAAAAAAAAAA",
-                "bc",
-                Some(vec![
-                    16, 13, 32, 17, 10, 42, 34, 7, 2, 37, 6, 48, 44, 28, 53, 4,
-                ]),
-                "QNGRK QIHCL GWSCE",
-            ),
-            (
-                "AAAAAAAAAAAAAAA",
-                "bcd",
-                Some(vec![
-                    5, 38, 20, 27, 50, 1, 38, 26, 49, 33, 39, 42, 49, 2, 35,
-                ]),
-                "FMUBY BMAXH NQXCJ",
-            ),
-            (
-                "AAAAAAAAAAAAAAAAAAAAAAAAA",
-                "cryptonomicon",
-                None,
-                "SUGSR SXSWQ RMXOH IPBFP XARYQ",
-            ),
-            ("SOLITAIRE", "cryptonomicon", None, "KIRAK SFJAN"),
-        ] {
-            dbg!(key);
-            let deck = Deck::from_passphrase(key);
-            if let Some(output) = output {
-                assert_eq!(
-                    &keystream(deck.clone())
-                        .take(output.len())
-                        .collect::<Vec<_>>(),
-                    output,
-                )
-            }
-            assert_eq!(&encrypt(deck, plain), cipher,)
+    #[rstest(plain, key, output, cipher,
+        case(
+            "AAAAAAAAAAAAAAA",
+            "",
+            Some(vec![
+                4, 49, 10, 53, 24, 8, 51, 44, 6, 4, 33, 20, 39, 19, 34, 42,
+            ]),
+            "EXKYI ZSGEH UNTIQ",
+        ),
+        case(
+            "AAAAAAAAAAAAAAA",
+            "f",
+            Some(vec![49, 24, 8, 46, 16, 1, 12, 33, 10, 10, 9, 27, 4, 32, 24]),
+            "XYIUQ BMHKK JBEGY",
+        ),
+        case(
+            "AAAAAAAAAAAAAAA",
+            "fo",
+            Some(vec![
+                19, 46, 9, 24, 12, 1, 4, 43, 11, 32, 23, 39, 29, 34, 22,
+            ]),
+            "TUJYM BERLG XNDIW",
+        ),
+        case(
+            "AAAAAAAAAAAAAAA",
+            "foo",
+            Some(vec![
+                8, 19, 7, 25, 20, 53, 9, 8, 22, 32, 43, 5, 26, 17, 53, 38, 48,
+            ]),
+            "ITHZU JIWGR FARMW",
+        ),
+        case(
+            "AAAAAAAAAAAAAAA",
+            "a",
+            Some(vec![
+                49, 14, 3, 26, 11, 32, 18, 2, 46, 37, 34, 42, 13, 18, 28,
+            ]),
+            "XODAL GSCUL IQNSC",
+        ),
+        case(
+            "AAAAAAAAAAAAAAA",
+            "aa",
+            Some(vec![14, 7, 32, 22, 38, 23, 23, 2, 26, 8, 12, 2, 34, 16, 15]),
+            "OHGWM XXCAI MCIQP",
+        ),
+        case(
+            "AAAAAAAAAAAAAAA",
+            "aaa",
+            Some(vec![
+                3, 28, 18, 42, 24, 33, 1, 16, 51, 53, 39, 6, 29, 43, 46, 45,
+            ]),
+            "DCSQY HBQZN GDRUT",
+        ),
+        case(
+            "AAAAAAAAAAAAAAA",
+            "b",
+            Some(vec![
+                49, 16, 4, 30, 12, 40, 8, 19, 37, 25, 47, 29, 18, 16, 18,
+            ]),
+            "XQEEM OITLZ VDSQS",
+        ),
+        case(
+            "AAAAAAAAAAAAAAA",
+            "bc",
+            Some(vec![
+                16, 13, 32, 17, 10, 42, 34, 7, 2, 37, 6, 48, 44, 28, 53, 4,
+            ]),
+            "QNGRK QIHCL GWSCE",
+        ),
+        case(
+            "AAAAAAAAAAAAAAA",
+            "bcd",
+            Some(vec![
+                5, 38, 20, 27, 50, 1, 38, 26, 49, 33, 39, 42, 49, 2, 35,
+            ]),
+            "FMUBY BMAXH NQXCJ",
+        ),
+        case(
+            "AAAAAAAAAAAAAAAAAAAAAAAAA",
+            "cryptonomicon",
+            None,
+            "SUGSR SXSWQ RMXOH IPBFP XARYQ",
+        ),
+        case("SOLITAIRE", "cryptonomicon", None, "KIRAK SFJAN"),
+    )]
+    fn vectors(plain: &str, key: &str, output: Option<Vec<u8>>, cipher: &str) {
+        dbg!(key);
+        let deck = Deck::from_passphrase(key);
+        if let Some(output) = output {
+            assert_eq!(
+                keystream(deck.clone())
+                    .take(output.len())
+                    .collect::<Vec<_>>(),
+                output,
+            )
         }
+        assert_eq!(&encrypt(deck, plain), cipher,)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,4 +173,111 @@ mod tests {
             assert_eq!(expect, plaintext);
         }
     }
+
+    #[test]
+    fn test_empty_key_produces_sorted_deck() {
+        assert_eq!(Deck::from_passphrase(""), Deck::new(),)
+    }
+
+    #[test]
+    /// tests from the vectors at: https://www.schneier.com/code/sol-test.txt
+    fn test_vectors() {
+        for (plain, key, output, cipher) in &[
+            (
+                "AAAAAAAAAAAAAAA",
+                "",
+                Some(vec![
+                    4, 49, 10, 53, 24, 8, 51, 44, 6, 4, 33, 20, 39, 19, 34, 42,
+                ]),
+                "EXKYI ZSGEH UNTIQ",
+            ),
+            (
+                "AAAAAAAAAAAAAAA",
+                "f",
+                Some(vec![49, 24, 8, 46, 16, 1, 12, 33, 10, 10, 9, 27, 4, 32, 24]),
+                "XYIUQ BMHKK JBEGY",
+            ),
+            (
+                "AAAAAAAAAAAAAAA",
+                "fo",
+                Some(vec![
+                    19, 46, 9, 24, 12, 1, 4, 43, 11, 32, 23, 39, 29, 34, 22,
+                ]),
+                "TUJYM BERLG XNDIW",
+            ),
+            (
+                "AAAAAAAAAAAAAAA",
+                "foo",
+                Some(vec![
+                    8, 19, 7, 25, 20, 53, 9, 8, 22, 32, 43, 5, 26, 17, 53, 38, 48,
+                ]),
+                "ITHZU JIWGR FARMW",
+            ),
+            (
+                "AAAAAAAAAAAAAAA",
+                "a",
+                Some(vec![
+                    49, 14, 3, 26, 11, 32, 18, 2, 46, 37, 34, 42, 13, 18, 28,
+                ]),
+                "XODAL GSCUL IQNSC",
+            ),
+            (
+                "AAAAAAAAAAAAAAA",
+                "aa",
+                Some(vec![14, 7, 32, 22, 38, 23, 23, 2, 26, 8, 12, 2, 34, 16, 15]),
+                "OHGWM XXCAI MCIQP",
+            ),
+            (
+                "AAAAAAAAAAAAAAA",
+                "aaa",
+                Some(vec![
+                    3, 28, 18, 42, 24, 33, 1, 16, 51, 53, 39, 6, 29, 43, 46, 45,
+                ]),
+                "DCSQY HBQZN GDRUT",
+            ),
+            (
+                "AAAAAAAAAAAAAAA",
+                "b",
+                Some(vec![
+                    49, 16, 4, 30, 12, 40, 8, 19, 37, 25, 47, 29, 18, 16, 18,
+                ]),
+                "XQEEM OITLZ VDSQS",
+            ),
+            (
+                "AAAAAAAAAAAAAAA",
+                "bc",
+                Some(vec![
+                    16, 13, 32, 17, 10, 42, 34, 7, 2, 37, 6, 48, 44, 28, 53, 4,
+                ]),
+                "QNGRK QIHCL GWSCE",
+            ),
+            (
+                "AAAAAAAAAAAAAAA",
+                "bcd",
+                Some(vec![
+                    5, 38, 20, 27, 50, 1, 38, 26, 49, 33, 39, 42, 49, 2, 35,
+                ]),
+                "FMUBY BMAXH NQXCJ",
+            ),
+            (
+                "AAAAAAAAAAAAAAAAAAAAAAAAA",
+                "cryptonomicon",
+                None,
+                "SUGSR SXSWQ RMXOH IPBFP XARYQ",
+            ),
+            ("SOLITAIRE", "cryptonomicon", None, "KIRAK SFJAN"),
+        ] {
+            dbg!(key);
+            let deck = Deck::from_passphrase(key);
+            if let Some(output) = output {
+                assert_eq!(
+                    &keystream(deck.clone())
+                        .take(output.len())
+                        .collect::<Vec<_>>(),
+                    output,
+                )
+            }
+            assert_eq!(&encrypt(deck, plain), cipher,)
+        }
+    }
 }


### PR DESCRIPTION
Vectors are from [here](https://www.schneier.com/code/sol-test.txt), linked to from [Schneier's page for this algorithm](https://www.schneier.com/academic/solitaire/). Conversion from the text format to the cases here was accomplished with a one-shot python script not included in this PR.